### PR TITLE
Update Double XP to start at midnight CET.

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -479,11 +479,10 @@ import Layout from "../layouts/Layout.astro";
             ],
         },
         {
-            // Weekend event starts Saturday at 6am and ends Sunday at midnight, which is different
             isEventRunning: (date: Date) =>
-                (isSaturday(date) && date.getHours() >= 6) || isSunday(date),
+                (isSaturday(date) || isSunday(date),
             getEndOfEvent: (date: Date) => {
-                if (isSaturday(date) && date.getHours() >= 6) {
+                if (isSaturday(date)) {
                     return addHours(endOfDay(date), 24);
                 } else if (isSunday(date)) {
                     return endOfDay(date);


### PR DESCRIPTION
Double XP starts at midnight CET (3 PM PST). At the time of this PR, it is currently running.

IIUC issue #1, this fixes that.